### PR TITLE
Add support for upgrading Spin plugins

### DIFF
--- a/crates/plugins/src/install.rs
+++ b/crates/plugins/src/install.rs
@@ -35,9 +35,9 @@ pub struct PluginInfo {
     version: Option<Version>,
 }
 impl PluginInfo {
-    pub fn new(name: String, repo_url: Url, version: Option<Version>) -> Self {
+    pub fn new(name: &str, repo_url: Url, version: Option<Version>) -> Self {
         Self {
-            name,
+            name: name.to_string(),
             repo_url,
             version,
         }

--- a/crates/plugins/src/install.rs
+++ b/crates/plugins/src/install.rs
@@ -126,9 +126,9 @@ impl PluginInstaller {
             }
         };
 
-        // Return early if plugin is already installed with latest version
+        // Disallow downgrades and reinstalling identical plugins
         if let Ok(installed) = get_plugin_manifest(&plugin_manifest.name, &self.plugins_dir) {
-            if installed.version >= plugin_manifest.version {
+            if installed.version > plugin_manifest.version || installed == plugin_manifest {
                 return Err(anyhow!(
                     "plugin {} already installed with version {} but attempting to install same or older version ({})",
                     installed.name,
@@ -189,6 +189,7 @@ impl PluginInstaller {
         archive.set_preserve_permissions(true);
         // Create subdirectory in plugins directory for this plugin
         let plugin_sub_dir = self.plugins_dir.join(plugin_name);
+        fs::remove_dir_all(&plugin_sub_dir).ok();
         fs::create_dir_all(&plugin_sub_dir)?;
         archive.unpack(&plugin_sub_dir)?;
         Ok(())

--- a/crates/plugins/src/lib.rs
+++ b/crates/plugins/src/lib.rs
@@ -7,7 +7,7 @@ pub mod uninstall;
 pub mod version_check;
 
 /// Directory where the manifests of installed plugins are stored.
-const PLUGIN_MANIFESTS_DIRECTORY_NAME: &str = "manifests";
+pub const PLUGIN_MANIFESTS_DIRECTORY_NAME: &str = "manifests";
 
 fn get_manifest_file_name(plugin_name: &str) -> String {
     format!("{}.json", plugin_name)

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -4,8 +4,10 @@ use semver::Version;
 use spin_plugins::{
     install::{ManifestLocation, PluginInfo, PluginInstaller},
     uninstall::PluginUninstaller,
+    PLUGIN_MANIFESTS_DIRECTORY_NAME,
 };
 use std::path::PathBuf;
+use tracing::log;
 use url::Url;
 
 const SPIN_PLUGINS_REPO: &str = "https://github.com/fermyon/spin-plugins/";
@@ -21,6 +23,9 @@ pub enum PluginCommands {
 
     /// Remove a plugin from your installation.
     Uninstall(Uninstall),
+
+    /// Upgrade one or all plugins
+    Upgrade(Upgrade),
     // TODO: consider Search command
 
     // TODO: consider List command
@@ -31,6 +36,7 @@ impl PluginCommands {
         match self {
             PluginCommands::Install(cmd) => cmd.run().await,
             PluginCommands::Uninstall(cmd) => cmd.run().await,
+            PluginCommands::Upgrade(cmd) => cmd.run().await,
         }
     }
 }
@@ -85,7 +91,7 @@ impl Install {
             // TODO: move all this parsing into clap to catch input errors.
             (Some(path), None, None) => ManifestLocation::Local(path),
             (None, Some(url), None) => ManifestLocation::Remote(url),
-            (None, None, Some(name)) => ManifestLocation::PluginsRepository(PluginInfo::new(name, Url::parse(SPIN_PLUGINS_REPO)?, self.version)),
+            (None, None, Some(name)) => ManifestLocation::PluginsRepository(PluginInfo::new(&name, Url::parse(SPIN_PLUGINS_REPO)?, self.version)),
             _ => return Err(anyhow::anyhow!("Must provide plugin name for plugin look up xor remote xor local path to plugin manifest")),
         };
         PluginInstaller::new(
@@ -113,6 +119,132 @@ pub struct Uninstall {
 impl Uninstall {
     pub async fn run(self) -> Result<()> {
         PluginUninstaller::new(&self.name, get_spin_plugins_directory()?).run()?;
+        Ok(())
+    }
+}
+
+#[derive(Parser, Debug)]
+pub struct Upgrade {
+    /// Name of Spin plugin to upgrade.
+    #[clap(
+        name = "PLUGIN_NAME",
+        conflicts_with = "ALL",
+        required_unless_present_any = ["ALL"],
+    )]
+    pub name: Option<String>,
+    /// Upgrade all plugins
+    #[clap(
+        short = 'a',
+        long = "all",
+        name = "ALL",
+        conflicts_with = "PLUGIN_NAME",
+        takes_value = false
+    )]
+    pub all: bool,
+    /// Source of local manifest file
+    #[clap(
+        name = "LOCAL_PLUGIN_MANIFEST",
+        short = 'f',
+        long = "file",
+        conflicts_with = "REMOTE_PLUGIN_MANIFEST",
+        conflicts_with = "PLUGIN_NAME"
+    )]
+    pub local_manifest_src: Option<PathBuf>,
+    /// Source of remote manifest file
+    #[clap(
+        name = "REMOTE_PLUGIN_MANIFEST",
+        short = 'u',
+        long = "url",
+        conflicts_with = "LOCAL_PLUGIN_MANIFEST",
+        conflicts_with = "PLUGIN_NAME"
+    )]
+    pub remote_manifest_src: Option<Url>,
+    /// skips prompt to accept the installation of the plugin.
+    #[clap(short = 'y', long = "yes", takes_value = false)]
+    pub yes_to_all: bool,
+    #[clap(
+        long = "version",
+        short = 'v',
+        conflicts_with = "REMOTE_PLUGIN_MANIFEST",
+        conflicts_with = "LOCAL_PLUGIN_MANIFEST",
+        requires("PLUGIN_NAME")
+    )]
+    /// Specify a particular version of the plugin to be installed from the centralized plugin repository
+    pub version: Option<Version>,
+    /// Allow downgrading a plugin's version
+    #[clap(short = 'd', long = "downgrade", takes_value = false)]
+    pub downgrade: bool,
+}
+
+impl Upgrade {
+    pub async fn run(self) -> Result<()> {
+        let plugins_dir = get_spin_plugins_directory()?;
+        let spin_version = env!("VERGEN_BUILD_SEMVER");
+
+        if self.all {
+            // Install the latest of all currently installed plugins
+            for plugin in std::fs::read_dir(&plugins_dir.join(PLUGIN_MANIFESTS_DIRECTORY_NAME))? {
+                let path = plugin
+                    .map_err(|e| anyhow!("No plugins are currently installed - {:?}", e))?
+                    .path();
+                let name = path
+                    .file_stem()
+                    .ok_or_else(|| anyhow!("expected directory for plugin"))?
+                    .to_str()
+                    .ok_or_else(|| anyhow!("Cannot convert directory to String"))?
+                    .to_string();
+                if let Err(e) = PluginInstaller::new(
+                    ManifestLocation::PluginsRepository(PluginInfo::new(
+                        &name,
+                        Url::parse(SPIN_PLUGINS_REPO)?,
+                        None,
+                    )),
+                    plugins_dir.clone(),
+                    self.yes_to_all,
+                    spin_version,
+                )
+                .install()
+                .await
+                {
+                    // Ignore plugins that were not installed from the central plugins repository
+                    if e.to_string().contains("Could not find plugin") {
+                        log::info!(
+                            "Could not update {} plugin as DNE in central repository",
+                            name
+                        );
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        } else {
+            let name = self
+                .name
+                .ok_or_else(|| anyhow!("plugin name required to downgrade"))?;
+            // If downgrade is allowed, first uninstall the plugin
+            if self.downgrade {
+                PluginUninstaller::new(&name, plugins_dir.clone()).run()?;
+            }
+            let manifest_location = match (self.local_manifest_src, self.remote_manifest_src) {
+                // TODO: move all this parsing into clap to catch input errors.
+                (Some(path), None) => ManifestLocation::Local(path),
+                (None, Some(url)) => ManifestLocation::Remote(url),
+                _ => ManifestLocation::PluginsRepository(PluginInfo::new(
+                    &name,
+                    Url::parse(SPIN_PLUGINS_REPO)?,
+                    self.version,
+                )),
+            };
+            PluginInstaller::new(
+                manifest_location,
+                plugins_dir,
+                self.yes_to_all,
+                spin_version,
+            )
+            .install()
+            .await?;
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
Support for upgrading plugins.
Implements upgrade functionality in `plugin.rs` as it mainly calls out to the install module.
The `all` flag can be tested by pointing to a branch [of spin-plugins in my fork](https://github.com/kate-goldenring/spin-plugins/tree/second-plugin) that has a second example plugin:
1. Set `const SPIN_PLUGINS_REPO: &str = "https://github.com/kate-goldenring/spin-plugins/";` in `plugin.rs` and  `const PLUGINS_REPO_BRANCH: &str = "second-plugin";` in `git.rs` 
2. Install older version of `example` and `karthik` plugins:
```
RUST_LOG=spin=trace ./target/release/spin plugin install example -v 0.1.0 -y
RUST_LOG=spin=trace ./target/release/spin plugin install karthik -v 0.1.0 -y
```
3. Upgrade to latest (`0.2.0`)
```
RUST_LOG=spin=trace ./target/release/spin plugin upgrade --all -y
```

Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>