### PR TITLE
Load Postgres certs from runtime config

### DIFF
--- a/crates/factor-outbound-pg/src/client.rs
+++ b/crates/factor-outbound-pg/src/client.rs
@@ -18,9 +18,10 @@ const CONNECTION_POOL_CACHE_CAPACITY: u64 = 16;
 /// A factory object for Postgres clients. This abstracts
 /// details of client creation such as pooling.
 #[async_trait]
-pub trait ClientFactory: Default + Send + Sync + 'static {
+pub trait ClientFactory: Send + Sync + 'static {
     /// The type of client produced by `get_client`.
     type Client: Client;
+    fn new(root_certificates: Vec<Vec<u8>>) -> Self;
     /// Gets a client from the factory.
     async fn get_client(&self, address: &str) -> Result<Self::Client>;
 }
@@ -28,24 +29,24 @@ pub trait ClientFactory: Default + Send + Sync + 'static {
 /// A `ClientFactory` that uses a connection pool per address.
 pub struct PooledTokioClientFactory {
     pools: moka::sync::Cache<String, deadpool_postgres::Pool>,
-}
-
-impl Default for PooledTokioClientFactory {
-    fn default() -> Self {
-        Self {
-            pools: moka::sync::Cache::new(CONNECTION_POOL_CACHE_CAPACITY),
-        }
-    }
+    root_certificates: Vec<Vec<u8>>,
 }
 
 #[async_trait]
 impl ClientFactory for PooledTokioClientFactory {
     type Client = deadpool_postgres::Object;
 
+    fn new(root_certificates: Vec<Vec<u8>>) -> Self {
+        Self {
+            pools: moka::sync::Cache::new(CONNECTION_POOL_CACHE_CAPACITY),
+            root_certificates,
+        }
+    }
+
     async fn get_client(&self, address: &str) -> Result<Self::Client> {
         let pool = self
             .pools
-            .try_get_with_by_ref(address, || create_connection_pool(address))
+            .try_get_with_by_ref(address, || create_connection_pool(address, &self.root_certificates))
             .map_err(ArcError)
             .context("establishing PostgreSQL connection pool")?;
 
@@ -54,7 +55,7 @@ impl ClientFactory for PooledTokioClientFactory {
 }
 
 /// Creates a Postgres connection pool for the given address.
-fn create_connection_pool(address: &str) -> Result<deadpool_postgres::Pool> {
+fn create_connection_pool(address: &str, root_certificates: &[Vec<u8>]) -> Result<deadpool_postgres::Pool> {
     let config = address
         .parse::<tokio_postgres::Config>()
         .context("parsing Postgres connection string")?;
@@ -69,14 +70,11 @@ fn create_connection_pool(address: &str) -> Result<deadpool_postgres::Pool> {
         deadpool_postgres::Manager::from_config(config, NoTls, mgr_config)
     } else {
         let mut builder = TlsConnector::builder();
-        let crt = r"-----BEGIN CERTIFICATE-----
-TODO: replace with PG CA
------END CERTIFICATE-----
-";
-        // This is an option to play around with setting the CA cert for the PG DB here. I couldn't get it working.
-        if config.get_ssl_mode() == SslMode::Require {
-            builder.add_root_certificate((native_tls::Certificate::from_pem(crt.as_bytes())?));
+        for cert_bytes in root_certificates {
+            builder.add_root_certificate(native_tls::Certificate::from_pem(cert_bytes)?);
         }
+        // let crt = std::fs::read("/home/ivan/github/spin/pg-app/postgres-ssl/ca.crt").unwrap();
+        // builder.add_root_certificate(native_tls::Certificate::from_pem(&crt)?);
 
         let connector = MakeTlsConnector::new(builder.build()?);
         deadpool_postgres::Manager::from_config(config, connector, mgr_config)

--- a/crates/factor-outbound-pg/src/lib.rs
+++ b/crates/factor-outbound-pg/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod client;
 mod host;
 mod types;
+pub mod runtime_config;
 
 use std::sync::Arc;
 
@@ -18,7 +19,7 @@ pub struct OutboundPgFactor<CF = crate::client::PooledTokioClientFactory> {
 }
 
 impl<CF: ClientFactory> Factor for OutboundPgFactor<CF> {
-    type RuntimeConfig = ();
+    type RuntimeConfig = runtime_config::RuntimeConfig;
     type AppState = Arc<CF>;
     type InstanceBuilder = InstanceState<CF>;
 
@@ -36,9 +37,14 @@ impl<CF: ClientFactory> Factor for OutboundPgFactor<CF> {
 
     fn configure_app<T: RuntimeFactors>(
         &self,
-        _ctx: ConfigureAppContext<T, Self>,
+        ctx: ConfigureAppContext<T, Self>,
     ) -> anyhow::Result<Self::AppState> {
-        Ok(Arc::new(CF::default()))
+        let certificates = match ctx.runtime_config() {
+            Some(rc) => rc.certificates.clone(),
+            None => vec![],
+        };
+        // let certificates = certificate_paths.iter().map(std::fs::read).collect::<Result<Vec<_>, _>>()?;
+        Ok(Arc::new(CF::new(certificates)))
     }
 
     fn prepare<T: RuntimeFactors>(

--- a/crates/factor-outbound-pg/src/runtime_config.rs
+++ b/crates/factor-outbound-pg/src/runtime_config.rs
@@ -1,0 +1,4 @@
+#[derive(Default)]
+pub struct RuntimeConfig {
+    pub certificates: Vec<Vec<u8>>,
+}

--- a/crates/factor-outbound-pg/tests/factor_test.rs
+++ b/crates/factor-outbound-pg/tests/factor_test.rs
@@ -105,13 +105,15 @@ async fn exercise_query() -> anyhow::Result<()> {
 }
 
 // TODO: We can expand this mock to track calls and simulate return values
-#[derive(Default)]
 pub struct MockClientFactory {}
 pub struct MockClient {}
 
 #[async_trait]
 impl ClientFactory for MockClientFactory {
     type Client = MockClient;
+    fn new(_: Vec<Vec<u8>>) -> Self {
+        Self {}
+    }
     async fn get_client(&self, _address: &str) -> Result<Self::Client> {
         Ok(MockClient {})
     }

--- a/crates/runtime-config/src/lib.rs
+++ b/crates/runtime-config/src/lib.rs
@@ -24,6 +24,7 @@ use spin_sqlite as sqlite;
 use spin_trigger::cli::UserProvidedPath;
 use toml::Value;
 
+mod pg;
 pub mod variables;
 
 /// The default state directory for the trigger.
@@ -137,9 +138,10 @@ where
         let outbound_networking = runtime_config_dir
             .clone()
             .map(OutboundNetworkingSpinRuntimeConfig::new);
-        let key_value_resolver = key_value_config_resolver(runtime_config_dir, state_dir.clone());
+        let key_value_resolver = key_value_config_resolver(runtime_config_dir.clone(), state_dir.clone());
         let sqlite_resolver = sqlite_config_resolver(state_dir.clone())
             .context("failed to resolve sqlite runtime config")?;
+        let pg_resolver = pg::PgConfigResolver { base_dir: runtime_config_dir.clone() };
 
         let toml = toml_resolver.toml();
         let log_dir = toml_resolver.log_dir()?;
@@ -150,6 +152,7 @@ where
             &key_value_resolver,
             outbound_networking.as_ref(),
             &sqlite_resolver,
+            &pg_resolver,
         );
 
         // Note: all valid fields in the runtime config must have been referenced at
@@ -302,6 +305,7 @@ pub struct TomlRuntimeConfigSource<'a, 'b> {
     key_value: &'a key_value::RuntimeConfigResolver,
     outbound_networking: Option<&'a OutboundNetworkingSpinRuntimeConfig>,
     sqlite: &'a sqlite::RuntimeConfigResolver,
+    pg_resolver: &'a pg::PgConfigResolver,
 }
 
 impl<'a, 'b> TomlRuntimeConfigSource<'a, 'b> {
@@ -310,12 +314,14 @@ impl<'a, 'b> TomlRuntimeConfigSource<'a, 'b> {
         key_value: &'a key_value::RuntimeConfigResolver,
         outbound_networking: Option<&'a OutboundNetworkingSpinRuntimeConfig>,
         sqlite: &'a sqlite::RuntimeConfigResolver,
+        pg_resolver: &'a pg::PgConfigResolver,
     ) -> Self {
         Self {
             toml: toml_resolver,
             key_value,
             outbound_networking,
             sqlite,
+            pg_resolver,
         }
     }
 }
@@ -349,8 +355,8 @@ impl FactorRuntimeConfigSource<VariablesFactor> for TomlRuntimeConfigSource<'_, 
 }
 
 impl FactorRuntimeConfigSource<OutboundPgFactor> for TomlRuntimeConfigSource<'_, '_> {
-    fn get_runtime_config(&mut self) -> anyhow::Result<Option<()>> {
-        Ok(None)
+    fn get_runtime_config(&mut self) -> anyhow::Result<Option<<OutboundPgFactor as spin_factors::Factor>::RuntimeConfig>> {
+        Ok(Some(self.pg_resolver.runtime_config_from_toml(&self.toml.table)?))
     }
 }
 

--- a/crates/runtime-config/src/pg.rs
+++ b/crates/runtime-config/src/pg.rs
@@ -1,0 +1,41 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use spin_factor_outbound_pg::runtime_config::RuntimeConfig;
+use spin_factors::runtime_config::toml::GetTomlValue;
+
+pub struct PgConfigResolver {
+    pub(crate) base_dir: Option<PathBuf>, // must have a value if any certs, but we need to deref it lazily
+}
+
+impl PgConfigResolver {
+    pub fn runtime_config_from_toml(&self, table: &impl GetTomlValue) -> anyhow::Result<RuntimeConfig> {
+        let Some(table) = table.get("postgres").and_then(|t| t.as_table()) else {
+            return Ok(Default::default());
+        };
+
+        let table: RuntimeConfigTable = RuntimeConfigTable::deserialize(table.clone())?;
+
+        let certificate_paths = table.root_certificates.iter().map(|s| PathBuf::from(s)).collect::<Vec<_>>();
+
+        let has_relative = certificate_paths.iter().any(|p| p.is_relative());
+
+        let certificate_paths = match (has_relative, self.base_dir.as_ref()) {
+            (false, _) => certificate_paths,
+            (true, None) => anyhow::bail!("the runtime config file contains relative certificate paths, but we could not determine the runtime config directory for them to be relative to"),
+            (true, Some(base)) => certificate_paths.into_iter().map(|p| base.join(p)).collect::<Vec<_>>(),
+        };
+
+        let certificates = certificate_paths.iter().map(std::fs::read).collect::<Result<Vec<_>, _>>()?;
+
+        Ok(RuntimeConfig {
+            certificates,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct RuntimeConfigTable {
+    #[serde(default)]
+    root_certificates: Vec<String>,
+}

--- a/pg-app/make-certs.sh
+++ b/pg-app/make-certs.sh
@@ -28,6 +28,8 @@ chmod 644 server.crt ca.crt
 # 7. Clean up the CSR (optional)
 rm server.csr
 
+cd ..
+
 psql -d postgres -c "ALTER SYSTEM SET ssl = 'on';" \
   -c "ALTER SYSTEM SET ssl_cert_file = '${PWD}/postgres-ssl/server.crt';" \
   -c "ALTER SYSTEM SET ssl_key_file = '${PWD}/postgres-ssl/server.key';" \

--- a/pg-app/runtime-config.toml
+++ b/pg-app/runtime-config.toml
@@ -1,0 +1,2 @@
+[postgres]
+root_certificates = ["postgres-ssl/ca.crt"]


### PR DESCRIPTION
This is pretty rough but works for the happy path.  It needs better error handling of course (and the usual linting), and I probably want to do some parsing sooner, and I need to figure out relative paths in the runtime config file.  **For now you'll need to modify the runtime config to point to your home directory instead of mine.**  But with that done you should be able to `spin up -f ./pg-app/ --build --runtime-config-file ./pg-app/runtime-config.toml` against a SSLful Postgres and well it worked on my machine.

Thanks again for figuring out the repro.  It was sooooo helpful.
